### PR TITLE
Used Deepcopy instead of var pointer

### DIFF
--- a/simulation_structure.py
+++ b/simulation_structure.py
@@ -1,6 +1,7 @@
 import random
 import math
 import numpy as np
+import copy
 
 
 ####### defaults #######
@@ -15,7 +16,8 @@ class synthetic_data():
         for each remaining node, generate a number.
         if the number is less than threshold_value, append to neighbours_list
         '''
-        other_nodes = list_of_nodes
+        # Are you trying to copy the 'list_of_nodes' list object and then produce neighbours?
+        other_nodes = copy.deepcopy(list_of_nodes)
         del other_nodes[start_node_index]
 
         neighbours_list = []


### PR DESCRIPTION
var_1 = list_a means var_1 is a pointer to list_a and not a copy.

copy.deepcopy() will duplicate the list.

The other way is to go

var_1 = [list_a]